### PR TITLE
bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,5 @@ docker image build --target prod -t argovis/react:major.minor.patch .
 ```
 
 Run this alongside the full stack of Argovis containers per the deployment manifests in [https://github.com/argovis/argovis_deployment](https://github.com/argovis/argovis_deployment).
+
+

--- a/argovis/src/pages/helpers.js
+++ b/argovis/src/pages/helpers.js
@@ -757,6 +757,7 @@ helpers.prepPlotlyState = function(markerSize){
 					// filter off any points that have null for color value, don't plot these.
 					let x = d[this.state.xKey].filter((e,j) => {return d[this.state.cKey][j] !== null})
 					let y = d[this.state.yKey].filter((e,j) => {return d[this.state.cKey][j] !== null})
+					let t = d['timestamp'].filter((e,j) => {return d[this.state.cKey][j] !== null}) // timestamp gets used to step through valid points later, keep it synced with the filtering 
 					let z = []
 					if(this.state.zKey !== '[2D plot]'){
 						z = d[this.state.zKey].filter((e,j) => {return d[this.state.cKey][j] !== null})
@@ -767,7 +768,7 @@ helpers.prepPlotlyState = function(markerSize){
 					filteredData[this.state.yKey] = y
 					filteredData[this.state.zKey] = z
 					filteredData[this.state.cKey] = c
-
+					filteredData['timestamp'] = t
 					return {
 						x: filteredData[this.state.xKey],
 						y: filteredData[this.state.yKey],


### PR DESCRIPTION
when filtering off points without a meaningful color, need to also filter down the `timestamp` vector whether or not its getting plotted, since its used to step through valid points after filtering.